### PR TITLE
Added feature for automatically creating legends

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>34.1.0</version>
 		<relativePath />
 	</parent>
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>Image_5D</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.0.4</version>
 
 	<name>Image5D</name>
 	<description>The Image5D plugins extend image stacks to 5 dimensions: x, y, channel (color), slice (z), frame (t).</description>

--- a/src/main/java/sc/fiji/i5d/Main.java
+++ b/src/main/java/sc/fiji/i5d/Main.java
@@ -59,13 +59,19 @@ public class Main {
 
 		final ImagePlus imp = IJ.getImage();
 		
-		final Set_Channel_Labels setlabels = new Set_Channel_Labels();
-		setlabels.run(null);
-		
-		IJ.wait(6000);
+		IJ.run("Measure");
+		IJ.selectWindow("20210616_TR_HypM_MOC2_CCR2KO_1B_3_ROI_002_2_I5D");
 		
 		final Image5D_Stack_to_RGB stackToRGB = new Image5D_Stack_to_RGB();
 		stackToRGB.run("");
+				
+		
+		
+//		final Set_Channel_Labels setlabels = new Set_Channel_Labels();
+//		setlabels.run(null);
+//		
+//		IJ.wait(4000);
+//		stackToRGB.run("");
 
 		final MyListener listener = new MyListener(imp);
 		addScrollListener(imp, listener, listener);

--- a/src/main/java/sc/fiji/i5d/Main.java
+++ b/src/main/java/sc/fiji/i5d/Main.java
@@ -33,7 +33,9 @@ POSSIBILITY OF SUCH DAMAGE.
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
+import sc.fiji.i5d.plugin.Image5D_Stack_to_RGB;
 import sc.fiji.i5d.plugin.Open_Image5D;
+import sc.fiji.i5d.plugin.Set_Channel_Labels;
 
 import java.awt.Component;
 import java.awt.Container;
@@ -56,6 +58,14 @@ public class Main {
 		openImage5D.run("");
 
 		final ImagePlus imp = IJ.getImage();
+		
+		final Set_Channel_Labels setlabels = new Set_Channel_Labels();
+		setlabels.run(null);
+		
+		IJ.wait(6000);
+		
+		final Image5D_Stack_to_RGB stackToRGB = new Image5D_Stack_to_RGB();
+		stackToRGB.run("");
 
 		final MyListener listener = new MyListener(imp);
 		addScrollListener(imp, listener, listener);

--- a/src/main/java/sc/fiji/i5d/gui/ChannelControl.java
+++ b/src/main/java/sc/fiji/i5d/gui/ChannelControl.java
@@ -329,7 +329,7 @@ public class ChannelControl extends Panel implements ItemListener,
 	@Override
 	public Dimension getPreferredSize() {
 		// TEMP FIX 07-04-2023: manually set width to 150
-		//int width = selectorPanel.getPreferredSize().width; [original replacement]
+		// int width = selectorPanel.getPreferredSize().width; //[original replacement]
 		int width = 150;
 		if (colorChooserDisplayed) {
 			width += cColorChooser.getPreferredSize().width;

--- a/src/main/java/sc/fiji/i5d/gui/ChannelControl.java
+++ b/src/main/java/sc/fiji/i5d/gui/ChannelControl.java
@@ -328,7 +328,9 @@ public class ChannelControl extends Panel implements ItemListener,
 
 	@Override
 	public Dimension getPreferredSize() {
-		int width = selectorPanel.getPreferredSize().width;
+		// TEMP FIX 07-04-2023: manually set width to 150
+		//int width = selectorPanel.getPreferredSize().width; [original replacement]
+		int width = 150;
 		if (colorChooserDisplayed) {
 			width += cColorChooser.getPreferredSize().width;
 		}


### PR DESCRIPTION
Hello, 

Not sure if this is still active. I have little experience with GitHub, so hope I'm doing this correctly.
Image_5D was hugely helpful in visualising my IMC experimental data.

The changes I made are as follows: 

I added a temporary fix that sets the selector panel width to 150px. From my experience, this window did not scale properly resulting in only partial display of the channel names.

I added a feature that allows the user to retain information of the original I5D after conversion to RGB.
This feature allows the user to store the channel names and corresponding colour in the results table.
From this results table, the user can then (for instance with a programmable macro) automatically create a legend.

Please let me know if I am not following the correct procedure or how to move forward.
Would love it if my changes can benefit someone else!

Kind regards,


Jan-Pieter Eversdijk